### PR TITLE
Add library.properties metadata file

### DIFF
--- a/PS2Kbd/library.properties
+++ b/PS2Kbd/library.properties
@@ -1,0 +1,10 @@
+name=PS2Kbd
+version=0.0.0
+author=michalhol
+maintainer=michalhol
+sentence=PS2 keyboard library for ESP32 or Arduino.
+paragraph=
+category=Signal Input/Output
+url=https://github.com/michalhol/ps2kbdlib
+architectures=*
+includes=PS2Kbd.h


### PR DESCRIPTION
Libraries in the Arduino Library 1.5 format (source files under the src subfolder) are required to have a library.properties file in the root folder. If this file is not present the library is not recognized by the Arduino IDE.

This file is also required for inclusion in the [Arduino Library Manager index](https://github.com/arduino/Arduino/wiki/Library-Manager-FAQ).

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#library-metadata