### PR TITLE
Resolve -Werror=reorder

### DIFF
--- a/PS2Kbd/src/PS2Kbd.cpp
+++ b/PS2Kbd/src/PS2Kbd.cpp
@@ -371,8 +371,8 @@ void PS2Kbd::begin() {
 }
 
 PS2Kbd::PS2Kbd(uint8_t dataPin, uint8_t clkPin)
-    :dataPin(dataPin),
-    clkPin(clkPin),
+    :clkPin(clkPin),
+    dataPin(dataPin),
     shift(0),
     modifs(0),
     cpslk(false),
@@ -383,10 +383,10 @@ PS2Kbd::PS2Kbd(uint8_t dataPin, uint8_t clkPin)
     skipCount(0),
     rc(0),
     CHARS(0x90),
-    fromChar(0),
-    toChar(0),
     fromRaw(0),
     toRaw(0),
+    fromChar(0),
+    toChar(0),
     ACK(false),
     updLEDs(false)
 

--- a/PS2Kbd/src/PS2Kbd.h
+++ b/PS2Kbd/src/PS2Kbd.h
@@ -36,7 +36,7 @@ class PS2Kbd {
         uint8_t skipCount;
         uint8_t rc;
         const uint8_t CHARS;
-        volatile uint8_t keyScancodeBuffer[256];
+        volatile uint8_t keyScancodeBuffer[256] = {NULL};
         volatile uint16_t fromRaw;
         volatile uint16_t toRaw;
 

--- a/PS2Kbd/src/PS2Kbd.h
+++ b/PS2Kbd/src/PS2Kbd.h
@@ -36,7 +36,7 @@ class PS2Kbd {
         uint8_t skipCount;
         uint8_t rc;
         const uint8_t CHARS;
-        volatile uint8_t keyScancodeBuffer[256] = {NULL};
+        volatile uint8_t keyScancodeBuffer[256] = {0};
         volatile uint16_t fromRaw;
         volatile uint16_t toRaw;
 


### PR DESCRIPTION
Resolve the Werror=reorder at compile time by reordering the initialization of attributes in the constructor.